### PR TITLE
Add XML namespace support to xmlfilecontent

### DIFF
--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -1829,12 +1829,17 @@
             </xsd:complexType>
       </xsd:element>
       <!-- =============================================================================== -->
-      <!-- ===========================  XML FILE CONTENT TEST  =========================== -->
+      <!-- ===========================  xml file content test (namespace-agnostic)  ====== -->
       <!-- =============================================================================== -->
       <xsd:element name="xmlfilecontent_test" substitutionGroup="oval-def:test">
             <xsd:annotation>
                   <xsd:documentation>The xmlfilecontent_test element is used to explore the contents of an xml file. This test allows specific pieces of an xml document specified using xpath to be tested. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a xmlfilecontent_object and the optional state element specifies the metadata to check.</xsd:documentation>
                   <xsd:appinfo>
+                        <oval:deprecated_info>
+                              <oval:version>5.12</oval:version>
+                              <oval:reason>This version of the xmlfilecontent family can't work with namespaces, which makes it unreliable, and to some extent even insecure. Use the xmlfilecontent512_test instead.</oval:reason>
+                              <oval:comment>This value has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                        </oval:deprecated_info>
                         <oval:element_mapping>
                               <oval:test>xmlfilecontent_test</oval:test>
                               <oval:object>xmlfilecontent_object</oval:object>
@@ -1870,6 +1875,11 @@
                   <xsd:documentation>The set of files to be evaluated may be identified with either a complete filepath or a path and filename. Only one of these options may be selected.</xsd:documentation>
                   <xsd:documentation>It is important to note that the 'max_depth' and 'recurse_direction' attributes of the 'behaviors' element do not apply to the 'filepath' element, only to the 'path' and 'filename' elements.  This is because the 'filepath' element represents an absolute path to a particular file and it is not possible to recurse over a file.</xsd:documentation>
                   <xsd:appinfo>
+                        <oval:deprecated_info>
+                              <oval:version>5.12</oval:version>
+                              <oval:reason>This version of the xmlfilecontent family can't work with namespaces, which makes it unreliable, and to some extent even insecure. Use the xmlfilecontent512_object instead.</oval:reason>
+                              <oval:comment>This value has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                        </oval:deprecated_info>
                         <sch:pattern id="ind-def_xmlfilecontent_object_verify_filter_state">
                               <sch:rule context="ind-def:xmlfilecontent_object//oval-def:filter">
                                     <sch:let name="parent_object" value="ancestor::ind-def:xmlfilecontent_object"/>
@@ -1962,6 +1972,187 @@
       <xsd:element name="xmlfilecontent_state" substitutionGroup="oval-def:state">
             <xsd:annotation>
                   <xsd:documentation>The xmlfilecontent_state element contains entities that are used to check the file path and name, as well as the xpath used and the value of the this xpath.</xsd:documentation>
+                  <xsd:appinfo>
+                        <oval:deprecated_info>
+                              <oval:version>5.12</oval:version>
+                              <oval:reason>This version of the xmlfilecontent family can't work with namespaces, which makes it unreliable, and to some extent even insecure. Use the xmlfilecontent512_state instead.</oval:reason>
+                              <oval:comment>This value has been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+                        </oval:deprecated_info>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:StateType">
+                              <xsd:sequence>
+                                    <xsd:element name="filepath" type="oval-def:EntityStateStringType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The filepath element specifies the absolute path for a file on the machine. A directory cannot be specified as a filepath.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="path" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The path element specifies the directory component of the absolute path to a file on the machine.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="filename" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The filename element specifies the name of the file.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="xpath" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>Specifies an XPath 1.0 expression to evaluate against the XML file specified by the filename entity.  This XPath 1.0 expression must evaluate to a list of zero or more text values which will be accessible in OVAL via instances of the value_of entity.  Any results from evaluating the XPath 1.0 expression other than a list of text strings (e.g., a nodes set) is considered an error.  The intention is that the text values be drawn from instances of a single, uniquely named element or attribute.  However, an OVAL interpreter is not required to verify this, so the author should define the XPath expression carefully.  Note that "equals" is the only valid operator for the xpath entity.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="value_of" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The value_of element checks the value(s) of the text node(s) or attribute(s) found.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <!-- =============================================================================== -->
+      <!-- ===========================  xml file content test (namespace-aware)  ========= -->
+      <!-- =============================================================================== -->
+      <xsd:element name="xmlfilecontent512_test" substitutionGroup="oval-def:test">
+            <xsd:annotation>
+                  <xsd:documentation>The xmlfilecontent512_test element is used to explore the contents of an xml file. This test allows specific pieces of an xml document specified using xpath to be tested. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a xmlfilecontent512_object and the optional state element specifies the metadata to check.</xsd:documentation>
+                  <xsd:appinfo>
+                        <oval:element_mapping>
+                              <oval:test>xmlfilecontent512_test</oval:test>
+                              <oval:object>xmlfilecontent512_object</oval:object>
+                              <oval:state>xmlfilecontent512_state</oval:state>
+                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">xmlfilecontent512_item</oval:item>
+                        </oval:element_mapping>
+                  </xsd:appinfo>
+                  <xsd:appinfo>
+                        <sch:pattern id="ind-def_xmltst">
+                              <sch:rule context="ind-def:xmlfilecontent512_test/ind-def:object">
+                                    <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/ind-def:xmlfilecontent512_object/@id"><sch:value-of select="../@id"/> - the object child element of a xmlfilecontent512_test must reference a xmlfilecontent512_object</sch:assert>
+                              </sch:rule>
+                              <sch:rule context="ind-def:xmlfilecontent512_test/ind-def:state">
+                                    <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/ind-def:xmlfilecontent512_state/@id"><sch:value-of select="../@id"/> - the state child element of a xmlfilecontent512_test must reference a xmlfilecontent512_state</sch:assert>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:TestType">
+                              <xsd:sequence>
+                                    <xsd:element name="object" type="oval-def:ObjectRefType" />
+                                    <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="xmlfilecontent512_object" substitutionGroup="oval-def:object">
+            <xsd:annotation>
+                  <xsd:documentation>The xmlfilecontent512_object element is used by a xml file content test to define the specific piece of an xml file(s) to be evaluated. The xmlfilecontent512_object will only collect regular files on UNIX systems and FILE_TYPE_DISK files on Windows systems. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+                  <xsd:documentation>The set of files to be evaluated may be identified with either a complete filepath or a path and filename. Only one of these options may be selected.</xsd:documentation>
+                  <xsd:documentation>It is important to note that the 'max_depth' and 'recurse_direction' attributes of the 'behaviors' element do not apply to the 'filepath' element, only to the 'path' and 'filename' elements.  This is because the 'filepath' element represents an absolute path to a particular file and it is not possible to recurse over a file.</xsd:documentation>
+                  <xsd:appinfo>
+                        <sch:pattern id="ind-def_xmlfilecontent512_object_verify_filter_state">
+                              <sch:rule context="ind-def:xmlfilecontent512_object//oval-def:filter">
+                                    <sch:let name="parent_object" value="ancestor::ind-def:xmlfilecontent512_object"/>
+                                    <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                                    <sch:let name="state_ref" value="."/>
+                                    <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                                    <sch:let name="state_name" value="local-name($reffed_state)"/>
+                                    <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='xmlfilecontent512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:ObjectType">
+                              <xsd:sequence>
+                                    <xsd:choice>
+                                          <xsd:element ref="oval-def:set"/>
+                                          <xsd:sequence>
+                                                <xsd:element name="behaviors" type="ind-def:FileBehaviors" minOccurs="0" maxOccurs="1"/>
+                                                <xsd:choice>
+                                                      <xsd:element name="filepath" type="oval-def:EntityObjectStringType">
+                                                            <xsd:annotation>
+                                                                  <xsd:documentation>The filepath element specifies the absolute path for a file on the machine. A directory cannot be specified as a filepath.</xsd:documentation>
+                                                                  <xsd:appinfo>
+                                                                        <sch:pattern id="ind-def_xmlobjfilepath">
+                                                                              <sch:rule context="ind-def:xmlfilecontent512_object/ind-def:filepath">
+                                                                                    <sch:assert test="not(preceding-sibling::ind-def:behaviors[@max_depth or @recurse_direction])"><sch:value-of select="../@id"/> - the max_depth and recurse_direction behaviors are not allowed with a filepath entity</sch:assert>
+                                                                              </sch:rule>
+                                                                        </sch:pattern>
+                                                                        <sch:pattern id="ind-def_xmlobjfilepath2">
+                                                                              <sch:rule context="ind-def:xmlfilecontent512_object/ind-def:filepath[not(@operation='equals' or not(@operation))]">
+                                                                                    <sch:assert test="not(preceding-sibling::ind-def:behaviors[@recurse_file_system='defined'])"><sch:value-of select="../@id"/> - the recurse_file_system behavior MUST not be set to 'defined' when a pattern match is used with a filepath entity.</sch:assert>
+                                                                              </sch:rule>
+                                                                        </sch:pattern>
+                                                                  </xsd:appinfo>
+                                                            </xsd:annotation>
+                                                      </xsd:element>
+                                                      <xsd:sequence>
+                                                          <xsd:element name="path" type="oval-def:EntityObjectStringType">
+                                                                <xsd:annotation>
+                                                                      <xsd:documentation>The path element specifies the directory component of the absolute path to a file on the machine.</xsd:documentation>
+                                                                      <xsd:appinfo>
+                                                                            <sch:pattern id="ind-def_xmlobjpath">
+                                                                                  <sch:rule context="ind-def:xmlfilecontent512_object/ind-def:path[not(@operation='equals' or not(@operation))]">
+                                                                                        <sch:assert test="not(preceding-sibling::ind-def:behaviors[@recurse_file_system='defined'])"><sch:value-of select="../@id"/> - the recurse_file_system behavior MUST not be set to 'defined' when a pattern match is used with a path entity.</sch:assert>
+                                                                                        <sch:assert test="not(preceding-sibling::ind-def:behaviors[@max_depth])"><sch:value-of select="../@id"/> - the max_depth behavior MUST not be used when a pattern match is used with a path entity.</sch:assert>
+                                                                                        <sch:assert test="not(preceding-sibling::ind-def:behaviors[@recurse_direction])"><sch:value-of select="../@id"/> - the recurse_direction behavior MUST not be used when a pattern match is used with a path entity.</sch:assert>
+                                                                                        <sch:assert test="not(preceding-sibling::ind-def:behaviors[@recurse])"><sch:value-of select="../@id"/> - the recurse behavior MUST not be used when a pattern match is used with a path entity.</sch:assert>
+                                                                                  </sch:rule>
+                                                                            </sch:pattern>
+                                                                      </xsd:appinfo>
+                                                                </xsd:annotation>
+                                                          </xsd:element>
+                                                          <xsd:element name="filename" type="oval-def:EntityObjectStringType">
+                                                                <xsd:annotation>
+                                                                      <xsd:documentation>The filename element specifies the name of the file.</xsd:documentation>
+                                                                      <xsd:appinfo>
+                                                                            <sch:pattern id="ind-def_xmlobjfilename">
+                                                                                  <sch:rule context="ind-def:xmlfilecontent512_object/ind-def:filename">
+                                                                                        <sch:assert test="(@var_ref and .='') or not(.='') or (.='' and @operation = 'pattern match')"><sch:value-of select="../@id"/> - filename entity cannot be empty unless the xsi:nil attribute is set to true or a var_ref is used</sch:assert>
+                                                                                  </sch:rule>
+                                                                            </sch:pattern>
+                                                                      </xsd:appinfo>
+                                                                </xsd:annotation>
+                                                          </xsd:element>
+                                                      </xsd:sequence>
+                                                </xsd:choice>
+                                                <xsd:element name="xpath" type="oval-def:EntityObjectStringType">
+                                                      <xsd:annotation>
+                                                            <xsd:documentation>Specifies an XPath 1.0 expression to evaluate against the XML file specified by the filename entity.  This XPath 1.0 expression must evaluate to a list of zero or more text values which will be accessible in OVAL via instances of the value_of entity.  Any results from evaluating the XPath 1.0 expression other than a list of text strings (e.g., a nodes set) is considered an error.  The intention is that the text values be drawn from instances of a single, uniquely named element or attribute.  However, an OVAL interpreter is not required to verify this, so the author should define the XPath expression carefully.  Note that "equals" is the only valid operator for the xpath entity.</xsd:documentation>
+                                                            <xsd:appinfo>
+                                                                  <sch:pattern id="ind-def_xmlobjxpath">
+                                                                        <sch:rule context="ind-def:xmlfilecontent512_object/ind-def:xpath">
+                                                                            <sch:assert test="not(@operation) or @operation='equals'"><sch:value-of select="../@id"/> - operation attribute for the xpath entity of a xmlfilecontent512_object should be 'equals', note that this overrules the general operation attribute validation (i.e. follow this one)</sch:assert>
+                                                                        </sch:rule>
+                                                                  </sch:pattern>
+                                                            </xsd:appinfo>
+                                                      </xsd:annotation>
+                                                </xsd:element>
+                                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                                          </xsd:sequence>
+                                    </xsd:choice>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="xmlfilecontent512_state" substitutionGroup="oval-def:state">
+            <xsd:annotation>
+                  <xsd:documentation>The xmlfilecontent512_state element contains entities that are used to check the file path and name, as well as the xpath used and the value of the this xpath.</xsd:documentation>
             </xsd:annotation>
             <xsd:complexType>
                   <xsd:complexContent>

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -2130,9 +2130,27 @@
                                                           </xsd:element>
                                                       </xsd:sequence>
                                                 </xsd:choice>
+                                                <xsd:element name="namespaces" minOccurs="0" maxOccurs="1">
+                                                      <xsd:complexType>
+                                                            <xsd:sequence>
+                                                                  <xsd:element name="nsmap" minOccurs="0" maxOccurs="unbounded">
+                                                                        <xsd:annotation>
+										<xsd:documentation>Specifies a prefix-namespace mapping to be used in the xpath expression. For example mapping of xsd to http://www.w3.org/2001/XMLSchema so one could use e.g. xsd:element in xpath would look like &lt;nsmap prefix="xsd"&gt;http://www.w3.org/2001/XMLSchema&lt;/nsmap&gt;</xsd:documentation>
+                                                                        </xsd:annotation>
+                                                                        <xsd:complexType>
+                                                                              <xsd:simpleContent>
+                                                                                    <xsd:extension base="xsd:string">
+                                                                                          <xsd:attribute name="prefix" type ="xsd:string" use="required"/>
+                                                                                    </xsd:extension>
+                                                                              </xsd:simpleContent>
+                                                                        </xsd:complexType>
+                                                                  </xsd:element>
+                                                            </xsd:sequence>
+                                                      </xsd:complexType>
+                                                </xsd:element>
                                                 <xsd:element name="xpath" type="oval-def:EntityObjectStringType">
                                                       <xsd:annotation>
-                                                            <xsd:documentation>Specifies an XPath 1.0 expression to evaluate against the XML file specified by the filename entity.  This XPath 1.0 expression must evaluate to a list of zero or more text values which will be accessible in OVAL via instances of the value_of entity.  Any results from evaluating the XPath 1.0 expression other than a list of text strings (e.g., a nodes set) is considered an error.  The intention is that the text values be drawn from instances of a single, uniquely named element or attribute.  However, an OVAL interpreter is not required to verify this, so the author should define the XPath expression carefully.  Note that "equals" is the only valid operator for the xpath entity.</xsd:documentation>
+                                                            <xsd:documentation>Specifies an XPath 1.0 expression to evaluate against the XML file specified by the filename entity.  This XPath 1.0 expression must evaluate to a list of zero or more text values which will be accessible in OVAL via instances of the value_of entity.  Any results from evaluating the XPath 1.0 expression other than a list of text strings (e.g., a nodes set) is considered an error.  The intention is that the text values be drawn from instances of a single, uniquely named element or attribute.  However, an OVAL interpreter is not required to verify this, so the author should define the XPath expression carefully.  Note that "equals" is the only valid operator for the xpath entity. The xpath expression can reference namespace prefixes defined by the namespaces/nsmap elements.</xsd:documentation>
                                                             <xsd:appinfo>
                                                                   <sch:pattern id="ind-def_xmlobjxpath">
                                                                         <sch:rule context="ind-def:xmlfilecontent512_object/ind-def:xpath">
@@ -2173,9 +2191,27 @@
                                                 <xsd:documentation>The filename element specifies the name of the file.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
+                                    <xsd:element name="namespaces" minOccurs="0" maxOccurs="1">
+                                          <xsd:complexType>
+                                                <xsd:sequence>
+                                                      <xsd:element name="nsmap" minOccurs="0" maxOccurs="unbounded">
+                                                            <xsd:annotation>
+                                                                  <xsd:documentation>Specifies a prefix-namespace mapping to be used in the xpath expression. For example mapping of xsd to http://www.w3.org/2001/XMLSchema so one could use e.g. xsd:element in xpath would look like &lt;nsmap prefix="xsd"&gt;http://www.w3.org/2001/XMLSchema&lt;/nsmap&gt;</xsd:documentation>
+                                                            </xsd:annotation>
+                                                            <xsd:complexType>
+                                                                  <xsd:simpleContent>
+                                                                        <xsd:extension base="xsd:string">
+                                                                              <xsd:attribute name="prefix" type ="xsd:string" use="required"/>
+                                                                        </xsd:extension>
+                                                                  </xsd:simpleContent>
+                                                            </xsd:complexType>
+                                                      </xsd:element>
+                                                </xsd:sequence>
+                                          </xsd:complexType>
+                                    </xsd:element>
                                     <xsd:element name="xpath" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>Specifies an XPath 1.0 expression to evaluate against the XML file specified by the filename entity.  This XPath 1.0 expression must evaluate to a list of zero or more text values which will be accessible in OVAL via instances of the value_of entity.  Any results from evaluating the XPath 1.0 expression other than a list of text strings (e.g., a nodes set) is considered an error.  The intention is that the text values be drawn from instances of a single, uniquely named element or attribute.  However, an OVAL interpreter is not required to verify this, so the author should define the XPath expression carefully.  Note that "equals" is the only valid operator for the xpath entity.</xsd:documentation>
+                                                <xsd:documentation>Specifies an XPath 1.0 expression to evaluate against the XML file specified by the filename entity.  This XPath 1.0 expression must evaluate to a list of zero or more text values which will be accessible in OVAL via instances of the value_of entity.  Any results from evaluating the XPath 1.0 expression other than a list of text strings (e.g., a nodes set) is considered an error.  The intention is that the text values be drawn from instances of a single, uniquely named element or attribute.  However, an OVAL interpreter is not required to verify this, so the author should define the XPath expression carefully.  Note that "equals" is the only valid operator for the xpath entity. The xpath expression can reference namespace prefixes defined by the namespaces/nsmap elements.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="value_of" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
This PR introduces the `xmlfilecontent512` test/object/state that allows to declare namespace prefixes to be used in the xpath element.

Declaring namespaces this way is widely supported in XML libraries: https://stackoverflow.com/a/40796315/592892